### PR TITLE
Ability to configure sample rate

### DIFF
--- a/P1_parser.py
+++ b/P1_parser.py
@@ -156,7 +156,7 @@ class ParseTelegrams(threading.Thread):
           timeelapsed = int(ts - prevts)
 
           # Only broadcast this data:tag if sufficient time has elapsed based on maxrate
-          if (mintimeinterval != -1) and (timeelapsed > mintimeinterval):
+          if (mintimeinterval != -1) and (timeelapsed >= mintimeinterval):
             dict[tag] = data
 
             # and store current ts

--- a/config.rename.py
+++ b/config.rename.py
@@ -40,6 +40,13 @@ MQTT_PASSWORD = "secret"
 # Set to 0 for unlimited rate
 MQTT_RATE = 100
 
+# Set max DSMR electricity measurements per hour to be queued & published to MQTT topic "dsmr/el"
+# Example: Disabled = 0, One per minute = 60, One every 30 seconds = 120, etc
+DSMR_EL_MAX_SAMPLE_RATE = 60
+# Set max DSMR gas measurements per hour to be queued & published to MQTT topic "dsmr/gas"
+# Example: Disabled = 0, One per minute = 60, One every 30 seconds = 120, etc
+DSMR_GAS_MAX_SAMPLE_RATE = 60
+
 if PRODUCTION:
   MQTT_TOPIC_PREFIX = "dsmr"
 else:

--- a/dsmr50.py
+++ b/dsmr50.py
@@ -29,6 +29,7 @@ INDEX = {
         You should have received a copy of the GNU General Public License
         along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+import config as cfg
 
 DESCRIPTION = 0       # Description, specify units of measure between []
 MQTT_TOPIC = 1        # MQTT base topic; will be packed in a json message
@@ -51,25 +52,25 @@ definition = {
 
 # set serial frequecy equal to el_consumed, then use it as as tag for influxdb; truncated to last 8 digits
 # If full serial is required, remove \d{26}
-"0-0:96.1.1":   ["Equipment identifier",          "el", "serial",              "^.*\(\d{26}(.*)\)","str",   "1",    "60", "0", "mdi:counter"],
+"0-0:96.1.1":   ["Equipment identifier",          "el", "serial",              "^.*\(\d{26}(.*)\)","str",   "1",    f"{cfg.DSMR_EL_MAX_SAMPLE_RATE}", "0", "mdi:counter"],
 "0-0:1.0.0":    ["Timestamp [s]",                 "el", "timestamp",           "^.*\((.*)W\)",     "int",   "1",    "0",   "0", "mdi:counter"],
 "0-0:96.7.21":  ["Number of power failures",      "el", "power_failures",      "^.*\((.*)\)",      "int",   "1",    "12",  "0", "mdi:counter"],
 "0-0:96.7.9":   ["Number of long power failures", "el", "long_power_failures", "^.*\((.*)\)",      "int",   "1",    "12",  "0", "mdi:counter"],
 "0-0:96.14.0":  ["Tariff indicator electricity",  "el", "tariff_indicator",    "^.*\((.*)\)",      "int",   "1",    "0",   "0", "mdi:counter"],
 
-"1-0:21.7.0":   ["Power usage L1 [W]",            "el", "P1_consumed",         "^.*\((.*)\*kW\)",  "float", "1000", "60",   "0", "mdi:gauge"],
-"1-0:41.7.0":   ["Power usage L2 [W]",            "el", "P2_consumed",         "^.*\((.*)\*kW\)",  "float", "1000", "60",   "0", "mdi:gauge"],
-"1-0:61.7.0":   ["Power usage L3 [W]",            "el", "P3_consumed",         "^.*\((.*)\*kW\)",  "float", "1000", "60",   "0", "mdi:gauge"],
-"1-0:22.7.0":   ["Power generation L1 [W]",       "el", "P1_generated",        "^.*\((.*)\*kW\)",  "float", "1000", "60",   "0", "mdi:gauge"],
-"1-0:42.7.0":   ["Power generation L2 [W]",       "el", "P2_generated",        "^.*\((.*)\*kW\)",  "float", "1000", "60",   "0", "mdi:gauge"],
-"1-0:62.7.0":   ["Power generation L3 [W]",       "el", "P3_generated",        "^.*\((.*)\*kW\)",  "float", "1000", "60",   "0", "mdi:gauge"],
-"1-0:1.7.0":    ["Total power usage [W]",         "el", "p_consumed",          "^.*\((.*)\*kW\)",  "float", "1000", "60", "1", "mdi:gauge"],
-"1-0:2.7.0":    ["Total power generation [W]",    "el", "p_generated",         "^.*\((.*)\*kW\)",  "float", "1000", "60", "1", "mdi:gauge"],
+"1-0:21.7.0":   ["Power usage L1 [W]",            "el", "P1_consumed",         "^.*\((.*)\*kW\)",  "float", "1000", f"{cfg.DSMR_EL_MAX_SAMPLE_RATE}",   "0", "mdi:gauge"],
+"1-0:41.7.0":   ["Power usage L2 [W]",            "el", "P2_consumed",         "^.*\((.*)\*kW\)",  "float", "1000", f"{cfg.DSMR_EL_MAX_SAMPLE_RATE}",   "0", "mdi:gauge"],
+"1-0:61.7.0":   ["Power usage L3 [W]",            "el", "P3_consumed",         "^.*\((.*)\*kW\)",  "float", "1000", f"{cfg.DSMR_EL_MAX_SAMPLE_RATE}",   "0", "mdi:gauge"],
+"1-0:22.7.0":   ["Power generation L1 [W]",       "el", "P1_generated",        "^.*\((.*)\*kW\)",  "float", "1000", f"{cfg.DSMR_EL_MAX_SAMPLE_RATE}",   "0", "mdi:gauge"],
+"1-0:42.7.0":   ["Power generation L2 [W]",       "el", "P2_generated",        "^.*\((.*)\*kW\)",  "float", "1000", f"{cfg.DSMR_EL_MAX_SAMPLE_RATE}",   "0", "mdi:gauge"],
+"1-0:62.7.0":   ["Power generation L3 [W]",       "el", "P3_generated",        "^.*\((.*)\*kW\)",  "float", "1000", f"{cfg.DSMR_EL_MAX_SAMPLE_RATE}",   "0", "mdi:gauge"],
+"1-0:1.7.0":    ["Total power usage [W]",         "el", "p_consumed",          "^.*\((.*)\*kW\)",  "float", "1000", f"{cfg.DSMR_EL_MAX_SAMPLE_RATE}", "1", "mdi:gauge"],
+"1-0:2.7.0":    ["Total power generation [W]",    "el", "p_generated",         "^.*\((.*)\*kW\)",  "float", "1000", f"{cfg.DSMR_EL_MAX_SAMPLE_RATE}", "1", "mdi:gauge"],
 
 # set serial frequency equal to gas_consumed, then use it as as tag for influxdb
 # If full serial is required, remove \d{26}
-"0-1:24.2.1":   ["gas consumption [m3]",          "gas", "gas_consumed",       "^.*\((.*)\*m3\)",  "float", "1000", "60", "1", "mdi:counter"],
-"0-1:96.1.0":   ["Equipment Identifier",          "gas", "serial",             "^.*\(\d{26}(.*)\)","str",   "1",    "60", "0", "mdi:counter"],
+"0-1:24.2.1":   ["gas consumption [m3]",          "gas", "gas_consumed",       "^.*\((.*)\*m3\)",  "float", "1000", f"{cfg.DSMR_GAS_MAX_SAMPLE_RATE}", "1", "mdi:counter"],
+"0-1:96.1.0":   ["Equipment Identifier",          "gas", "serial",             "^.*\(\d{26}(.*)\)","str",   "1",    f"{cfg.DSMR_GAS_MAX_SAMPLE_RATE}", "0", "mdi:counter"],
 
 "1-0:1.8.1":    ["EL consumed (Tariff 1) [Wh]",   "el", "el_consumed1",        "^.*\((.*)\*kWh\)", "float", "1000", "0", "0", "mdi:counter"],
 "1-0:1.8.2":    ["EL consumed (Tariff 2) [Wh]",   "el", "el_consumed2",        "^.*\((.*)\*kWh\)", "float", "1000", "0", "0", "mdi:counter"],
@@ -77,12 +78,12 @@ definition = {
 "1-0:2.8.2":    ["EL returned (Tariff 2) [Wh]",   "el", "el_returned2",        "^.*\((.*)\*kWh\)", "float", "1000", "0", "0", "mdi:counter"],
 
 # Virtual, not existing in dsmr telegram & specification, to sum tarif 1 & 2 to a single message
-"1-0:1.8.3":    ["EL consumed [Wh]",              "el", "el_consumed",         "^.*\((.*)\*kWh\)", "float", "1000", "60", "1", "mdi:counter"],
-"1-0:2.8.3":    ["EL returned [Wh]",              "el", "el_returned",         "^.*\((.*)\*kWh\)", "float", "1000", "60", "1", "mdi:counter"],
+"1-0:1.8.3":    ["EL consumed [Wh]",              "el", "el_consumed",         "^.*\((.*)\*kWh\)", "float", "1000", f"{cfg.DSMR_EL_MAX_SAMPLE_RATE}", "1", "mdi:counter"],
+"1-0:2.8.3":    ["EL returned [Wh]",              "el", "el_returned",         "^.*\((.*)\*kWh\)", "float", "1000", f"{cfg.DSMR_EL_MAX_SAMPLE_RATE}", "1", "mdi:counter"],
 
-"1-0:32.7.0":   ["Voltage L1 [V]",                "el",     "V1",              "^.*\((.*)\*V\)",   "float", "1",    "60", "1", "mdi:gauge"],
-"1-0:52.7.0":   ["Voltage L2 [V]",                "el",     "V2",              "^.*\((.*)\*V\)",   "float", "1",    "60", "1", "mdi:gauge"],
-"1-0:72.7.0":   ["Voltage L3 [V]",                "el",     "V3",              "^.*\((.*)\*V\)",   "float", "1",    "60", "1", "mdi:gauge"],
+"1-0:32.7.0":   ["Voltage L1 [V]",                "el",     "V1",              "^.*\((.*)\*V\)",   "float", "1",    f"{cfg.DSMR_EL_MAX_SAMPLE_RATE}", "1", "mdi:gauge"],
+"1-0:52.7.0":   ["Voltage L2 [V]",                "el",     "V2",              "^.*\((.*)\*V\)",   "float", "1",    f"{cfg.DSMR_EL_MAX_SAMPLE_RATE}", "1", "mdi:gauge"],
+"1-0:72.7.0":   ["Voltage L3 [V]",                "el",     "V3",              "^.*\((.*)\*V\)",   "float", "1",    f"{cfg.DSMR_EL_MAX_SAMPLE_RATE}", "1", "mdi:gauge"],
 "1-0:31.7.0":   ["Current L1 [A]",                "el",     "I1",              "^.*\((.*)\*A\)",   "int",   "1",    "0",   "0", "mdi:gauge"],
 "1-0:51.7.0":   ["Current L2 [A]",                "el",     "I2",              "^.*\((.*)\*A\)",   "int",   "1",    "0",   "0", "mdi:gauge"],
 "1-0:71.7.0":   ["Current L3 [A]",                "el",     "I3",              "^.*\((.*)\*A\)",   "int",   "1",    "0",   "0", "mdi:gauge"],


### PR DESCRIPTION
Hey there,

Thank you for this amazing tool! I bought myself a P1 cable yesterday to integrate my energy usage into HomeAssistant.
I'm investigating my energy usage at the moment and needed a higher sample rate than once per minute (10s) in order to have a 'live' view of the current power usage to find some devices that draw a lot of power.

I created a fork with a (quick & dirty) way to set the sample rate in the config.py.

If you like this small addition you could merge this PR, if not you can just decline this and I'll keep using my fork :). PR feedback is fine too if I need to improve on some stuff before approval.