### PR TITLE
Update hadiscovery.py for mqtt naming change

### DIFF
--- a/hadiscovery.py
+++ b/hadiscovery.py
@@ -68,7 +68,7 @@ class Discovery(threading.Thread):
     d = {}  # d = dict() does not work....
 
     # create device JSON
-    d["name"] = "dsmr reader"
+    d["name"] = "Status"
     d["unique_id"] = "dsmr-device"
     d["state_topic"] = cfg.MQTT_TOPIC_PREFIX + "/status"
     d["icon"] = "mdi:home-automation"


### PR DESCRIPTION
Home assistant Version 2023.07.1 gives a warning. The online/offline status entity has the same name as the device.
Unless it's updated it will break in version 2024.2.0 more info at https://developers.home-assistant.io/blog/2023-057-21-change-naming-mqtt-entities/

**Warning in Home Assistant:**

Discovered entities with a name that starts with the device name

This stops working in version 2024.2.0. Please address before upgrading.

Some MQTT entities have an entity name that starts with the device name. This is not expected. To avoid a duplicate name the device name prefix is stripped of the entity name as a work-a-round. Please inform the maintainer of the software application that supplies the affected entities to fix this issue.

List of affected entities:

sensor.dsmr_reader